### PR TITLE
CSS display none is undesirable in runtime_exception view file.

### DIFF
--- a/application/views/runtime_exception.php
+++ b/application/views/runtime_exception.php
@@ -31,7 +31,7 @@
     <div id="site_content">
       <h1>Runtime Error</h1>
       <div id="content">
-        <div id="error_dialog" title="Error" style="display: none">
+        <div id="error_dialog" title="Error">
           <p id="statusMessage" class="error"><?php echo nl2br(htmlspecialchars($statusMessage)); ?></p>
         </div>
       </div>


### PR DESCRIPTION
Resolves #6, errors will be visible if Javascript doesn't load.